### PR TITLE
add forceful termination for bots

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,13 @@ async function run(): Promise<void> {
 		const {actor} = context; // Core.getInput('user') - future
 		const {owner, repo} = context.repo;
 
+		if (actor.endsWith('[bot]')) {
+			core.info('Forceful termination, actor is a bot (variables are empty).');
+			core.setOutput('groups', []);
+			core.setOutput('highest-group', '');
+			process.exit();
+		}
+
 		const token: string = core.getInput('github-token');
 
 		const octokit = getOctokit(token);


### PR DESCRIPTION
Closes #41, checks for bot tag on the end of `context.actor`.